### PR TITLE
Add default license location to check

### DIFF
--- a/src/NServiceBus.AzureFunctions.StorageQueues/Serverless/ServerlessEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/Serverless/ServerlessEndpointConfiguration.cs
@@ -30,6 +30,13 @@
             EndpointConfiguration.UniquelyIdentifyRunningInstance()
                 .UsingCustomDisplayName(functionAppName)
                 .UsingCustomIdentifier(DeterministicGuid.Create(functionAppName));
+
+            // Look for license as an environment variable
+            var licenseText = Environment.GetEnvironmentVariable("NSERVICEBUS_LICENSE");
+            if (!string.IsNullOrWhiteSpace(licenseText))
+            {
+                EndpointConfiguration.License(licenseText);
+            }
         }
 
         internal EndpointConfiguration EndpointConfiguration { get; }


### PR DESCRIPTION
The built-in locations which are checked for licenses aren't useful when running in a Functions environment as it's checking `Environment.SpecialFolder.LocalApplicationData`, `Environment.SpecialFolder.CommonApplicationData` and `AppDomain.CurrentDomain.BaseDirectory` which are all not usable.

This PR additionally checks the following locations for licenses by default:
* Looks for a license in the environment variables

Discussed and agreed that we'll follow Azure convention and scan for an environment variable/Azure Functions setting named `NSERVICEBUS_LICENSE`. This will also be more secure than expecting the license file to be packaged along with the bits and potentially leaking if committed.
