### PR TITLE
Fix namespaces and remove redundant generic

### DIFF
--- a/src/NServiceBus.AzureFunctions.StorageQueues/AttributeDiscoverer.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/AttributeDiscoverer.cs
@@ -1,4 +1,4 @@
-namespace NServiceBus.AzureFunctions
+namespace NServiceBus.AzureFunctions.StorageQueues
 {
     using System;
     using System.Diagnostics;

--- a/src/NServiceBus.AzureFunctions.StorageQueues/FunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/FunctionEndpoint.cs
@@ -5,7 +5,6 @@
     using System.Threading;
     using System.Threading.Tasks;
     using Azure.Transports.WindowsAzureStorageQueues;
-    using AzureFunctions;
     using AzureFunctions.StorageQueues;
     using Extensibility;
     using global::Newtonsoft.Json;

--- a/src/NServiceBus.AzureFunctions.StorageQueues/Logging/FunctionsLoggerFactory.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/Logging/FunctionsLoggerFactory.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AzureFunctions
+﻿namespace NServiceBus.AzureFunctions.StorageQueues
 {
     using System;
     using System.Threading;

--- a/src/NServiceBus.AzureFunctions.StorageQueues/Logging/Logger.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/Logging/Logger.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AzureFunctions
+﻿namespace NServiceBus.AzureFunctions.StorageQueues
 {
     using System;
     using System.Threading;

--- a/src/NServiceBus.AzureFunctions.StorageQueues/Serverless/Configuration/ServerlessTransportExtensions.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/Serverless/Configuration/ServerlessTransportExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AzureFunctions
+﻿namespace NServiceBus.AzureFunctions.StorageQueues
 {
     using Configuration.AdvancedExtensibility;
     using Transport;

--- a/src/NServiceBus.AzureFunctions.StorageQueues/Serverless/Recoverability/ServerlessRecoverabilityPolicy.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/Serverless/Recoverability/ServerlessRecoverabilityPolicy.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AzureFunctions
+﻿namespace NServiceBus.AzureFunctions.StorageQueues
 {
     using System;
     using Transport;

--- a/src/NServiceBus.AzureFunctions.StorageQueues/Serverless/ServerlessEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/Serverless/ServerlessEndpoint.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AzureFunctions
+﻿namespace NServiceBus.AzureFunctions.StorageQueues
 {
     using System;
     using System.IO;

--- a/src/NServiceBus.AzureFunctions.StorageQueues/Serverless/ServerlessEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/Serverless/ServerlessEndpointConfiguration.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AzureFunctions
+﻿namespace NServiceBus.AzureFunctions.StorageQueues
 {
     using System;
     using System.Security.Cryptography;

--- a/src/NServiceBus.AzureFunctions.StorageQueues/Serverless/TransportWrapper/ManualPipelineInvocationInfrastructure.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/Serverless/TransportWrapper/ManualPipelineInvocationInfrastructure.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AzureFunctions
+﻿namespace NServiceBus.AzureFunctions.StorageQueues
 {
     using System.Threading.Tasks;
     using Transport;

--- a/src/NServiceBus.AzureFunctions.StorageQueues/Serverless/TransportWrapper/NoOpQueueCreator.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/Serverless/TransportWrapper/NoOpQueueCreator.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AzureFunctions
+﻿namespace NServiceBus.AzureFunctions.StorageQueues
 {
     using System.Threading.Tasks;
     using Transport;

--- a/src/NServiceBus.AzureFunctions.StorageQueues/Serverless/TransportWrapper/PipelineInvoker.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/Serverless/TransportWrapper/PipelineInvoker.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AzureFunctions
+﻿namespace NServiceBus.AzureFunctions.StorageQueues
 {
     using System;
     using System.Threading.Tasks;

--- a/src/NServiceBus.AzureFunctions.StorageQueues/Serverless/TransportWrapper/ServerlessTransport.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/Serverless/TransportWrapper/ServerlessTransport.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AzureFunctions
+﻿namespace NServiceBus.AzureFunctions.StorageQueues
 {
     using Settings;
     using Transport;
@@ -18,7 +18,7 @@
         public override TransportInfrastructure Initialize(SettingsHolder settings, string connectionString)
         {
             var baseTransportInfrastructure = baseTransport.Initialize(settings, connectionString);
-            return new ServerlessTransportInfrastructure<TBaseTransport>(baseTransportInfrastructure, settings);
+            return new ServerlessTransportInfrastructure(baseTransportInfrastructure, settings);
         }
 
         readonly TBaseTransport baseTransport;

--- a/src/NServiceBus.AzureFunctions.StorageQueues/Serverless/TransportWrapper/ServerlessTransportInfrastructure.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/Serverless/TransportWrapper/ServerlessTransportInfrastructure.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AzureFunctions
+﻿namespace NServiceBus.AzureFunctions.StorageQueues
 {
     using System;
     using System.Collections.Generic;
@@ -6,7 +6,7 @@
     using Settings;
     using Transport;
 
-    class ServerlessTransportInfrastructure<TBaseInfrastructure> : TransportInfrastructure
+    class ServerlessTransportInfrastructure : TransportInfrastructure
     {
         public ServerlessTransportInfrastructure(TransportInfrastructure baseTransportInfrastructure,
             SettingsHolder settings)

--- a/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
@@ -2,7 +2,7 @@
 {
     using Logging;
     using System;
-    using AzureFunctions;
+    using AzureFunctions.StorageQueues;
     using Microsoft.Azure.WebJobs;
 
     /// <summary>

--- a/src/StorageQueues.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/StorageQueues.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -1,5 +1,5 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute(@"StorageQueues.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001007f16e21368ff041183fab592d9e8ed37e7be355e93323147a1d29983d6e591b04282e4da0c9e18bd901e112c0033925eb7d7872c2f1706655891c5c9d57297994f707d16ee9a8f40d978f064ee1ffc73c0db3f4712691b23bf596f75130f4ec978cf78757ec034625a5f27e6bb50c618931ea49f6f628fd74271c32959efb1c5")]
-namespace NServiceBus.AzureFunctions
+namespace NServiceBus.AzureFunctions.StorageQueues
 {
     public abstract class ServerlessEndpointConfiguration
     {
@@ -12,7 +12,7 @@ namespace NServiceBus.AzureFunctions
             where TTransport : NServiceBus.Transport.TransportDefinition, new () { }
     }
     public abstract class ServerlessEndpoint<TConfiguration>
-        where TConfiguration : NServiceBus.AzureFunctions.ServerlessEndpointConfiguration
+        where TConfiguration : NServiceBus.AzureFunctions.StorageQueues.ServerlessEndpointConfiguration
     {
         protected System.Func<NServiceBus.FunctionExecutionContext, string> AssemblyDirectoryResolver;
         protected ServerlessEndpoint(System.Func<NServiceBus.FunctionExecutionContext, TConfiguration> configurationFactory) { }
@@ -23,7 +23,7 @@ namespace NServiceBus.AzureFunctions
 }
 namespace NServiceBus
 {
-    public class FunctionEndpoint : NServiceBus.AzureFunctions.ServerlessEndpoint<NServiceBus.StorageQueueTriggeredEndpointConfiguration>
+    public class FunctionEndpoint : NServiceBus.AzureFunctions.StorageQueues.ServerlessEndpoint<NServiceBus.StorageQueueTriggeredEndpointConfiguration>
     {
         public FunctionEndpoint(System.Func<NServiceBus.FunctionExecutionContext, NServiceBus.StorageQueueTriggeredEndpointConfiguration> configurationFactory) { }
         public System.Threading.Tasks.Task Process(Microsoft.WindowsAzure.Storage.Queue.CloudQueueMessage message, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null) { }
@@ -34,7 +34,7 @@ namespace NServiceBus
         public Microsoft.Azure.WebJobs.ExecutionContext ExecutionContext { get; }
         public Microsoft.Extensions.Logging.ILogger Logger { get; }
     }
-    public class StorageQueueTriggeredEndpointConfiguration : NServiceBus.AzureFunctions.ServerlessEndpointConfiguration
+    public class StorageQueueTriggeredEndpointConfiguration : NServiceBus.AzureFunctions.StorageQueues.ServerlessEndpointConfiguration
     {
         public StorageQueueTriggeredEndpointConfiguration(string endpointName, string connectionStringName = null) { }
         public NServiceBus.TransportExtensions<NServiceBus.AzureStorageQueueTransport> Transport { get; }


### PR DESCRIPTION
Only 3 types should be at the root NServiceBus namespace scope
- `FunctionEndpoint`
- `FunctionExecutionContext`
- `ServiceBusTriggeredEndpointConfiguration`

everything else should be scoped to the NServiceBus.AzureFunctions.StorageQueues namespace