### PR TITLE
Disable diagnostic

### DIFF
--- a/src/StorageQueues.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/StorageQueues.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -6,6 +6,7 @@ namespace NServiceBus.AzureFunctions.StorageQueues
         protected ServerlessEndpointConfiguration(string endpointName) { }
         public NServiceBus.EndpointConfiguration AdvancedConfiguration { get; }
         public void DoNotSendMessagesToErrorQueue() { }
+        public void LogDiagnostics() { }
         public NServiceBus.Serialization.SerializationExtensions<T> UseSerialization<T>()
             where T : NServiceBus.Serialization.SerializationDefinition, new () { }
         protected NServiceBus.TransportExtensions<TTransport> UseTransport<TTransport>()


### PR DESCRIPTION
fixes #12 by disabling diagnostics by default. Users can opt-in into diagnostics information by calling `config.LogDiagnostics()` which will put the diagnostic information into the log stream. This hasn't been made the default as it causes a significant amount of log data every time the function endpoint is started and the log output is associated with the specific invocation which happens to start the endpoint, so it might be difficult to find the correct trigger which contains the diagnostics data. There is still the ability to override the configuration and use a custom diagnostic-persistence approach if needed.

TODO:
* [x] [Fix on release-0.2 branch](https://github.com/Particular/NServiceBus.AzureFunctions.StorageQueues/pull/14)
* [x] update doc for new API