### PR TITLE
Lower Microsoft.Azure.WebJobs.Extensions.Storage dependency to handle messages with BOM

### DIFF
--- a/src/NServiceBus.AzureFunctions.StorageQueues/NServiceBus.AzureFunctions.StorageQueues.csproj
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/NServiceBus.AzureFunctions.StorageQueues.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="[2.2.0, 3)" />
     <PackageReference Include="NServiceBus.Azure.Transports.WindowsAzureStorageQueues" Version="[8.2.2, 9)" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="[4.0.2, 5.0.0)" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="[3.0.0, 4)" />
     <PackageReference Include="Particular.CodeRules" Version="0.3.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.8.0" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
Lowers the `Microsoft.Azure.WebJobs.Extensions.Storage` dependency from v4 to v3. v4 and v3 use a different `CloudQueueMessage` types due to a different dependency on the storage client (v3 uses `WindowsAzure.Storage` while v4 uses `Microsoft.Azure.Storage.Queue`). While testing it doesn't look like the Functions runtime can map the incoming message to the v4  `CloudQueueMessage` type. This is due to the deserialization issue as NServiceBus ASQ messages contain BOM, which `Microsoft.Azure.Storage.Queue` doesn't handle and `WindowsAzure.Storage` does.

In addition, our transport also uses  `WindowsAzure.Storage` so it makes sense to align the dependencies on the same client package.
v3 is also the default when creating new StorageQueue based Azure Functions, so it should improve the overall experience for now.