### PR TITLE
Enable delayed delivery

### DIFF
--- a/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.StorageQueues/StorageQueueTriggeredEndpointConfiguration.cs
@@ -36,7 +36,7 @@
             recoverability.Immediate(settings => settings.NumberOfRetries(4));
             recoverability.Delayed(settings => settings.NumberOfRetries(0));
 
-            Transport.DelayedDelivery().DisableDelayedDelivery();
+            Transport.DelayedDelivery().DisableTimeoutManager();
 
             EndpointConfiguration.UseSerialization<NewtonsoftSerializer>();
         }


### PR DESCRIPTION
As discussed with @SeanFeldman today, we're currently disabling delayed delivery completely. This makes it impossible for users to enable delayed delivery in case they want to use app service plan which should the support delayed delivery mechanisms used by the ASQ transport.
This change re-enables delayed delivery but disabled the timeout manager which is enabled for legacy support. This way, the endpoint doesn't request a timeout persister to be configured.